### PR TITLE
Memoize scrubbed method names for ~15% parsing time decrease

### DIFF
--- a/fitparse/processors.py
+++ b/fitparse/processors.py
@@ -19,18 +19,43 @@ class FitFileDataProcessor(object):
     #def process_units_<unit_name> (field_data)
     #def process_message_<mesg_name / mesg_type_num> (data_message)
 
+    # Used to memoize scrubbed method names
+    _scrubbed_method_names = {}
+
+    def _scrub_method_name(self, method_name):
+        """Scrubs a method name, returning result from local cache if available.
+
+        This method wraps fitparse.utils.scrub_method_name and memoizes results,
+        as scrubbing a method name is expensive.
+
+        Args:
+            method_name: Method name to scrub.
+
+        Returns:
+            Scrubbed method name.
+        """
+        if method_name not in self._scrubbed_method_names:
+            self._scrubbed_method_names[method_name] = (
+                scrub_method_name(method_name))
+
+        return self._scrubbed_method_names[method_name]
+
     def run_type_processor(self, field_data):
-        self._run_processor(scrub_method_name('process_type_%s' % field_data.type.name), field_data)
+        self._run_processor(self._scrub_method_name(
+            'process_type_%s' % field_data.type.name), field_data)
 
     def run_field_processor(self, field_data):
-        self._run_processor(scrub_method_name('process_field_%s' % field_data.name), field_data)
+        self._run_processor(self._scrub_method_name(
+            'process_field_%s' % field_data.name), field_data)
 
     def run_unit_processor(self, field_data):
         if field_data.units:
-            self._run_processor(scrub_method_name('process_units_%s' % field_data.units), field_data)
+            self._run_processor(self._scrub_method_name(
+                'process_units_%s' % field_data.units), field_data)
 
     def run_message_processor(self, data_message):
-        self._run_processor(scrub_method_name('process_message_%s' % data_message.def_mesg.name), data_message)
+        self._run_processor(self._scrub_method_name(
+            'process_message_%s' % data_message.def_mesg.name), data_message)
 
     def _run_processor(self, processor_name, data):
         try:


### PR DESCRIPTION
Scrubbing {type,field,unit} processor method names uses expensive regex
operations. Processors are run multiple times per message, but the set of
method names scrubbed for a given .fit file is small (for a 281.13 KiB
.fit file with power, cadence, and heart rate, `scrub_method_name` was called
299920 times but only 300 unique method names were scrubbed).

Here are parsing runtimes for .fit files of two sizes, both with power,
cadence, and heart rate, before and after the changes of this commit
(average of 5 trials):

1.56 MiB file:
```
Before: 19.76s
After:  16.78s
Decrease: 2.98s, 15.06%
```

281.13 KiB file:
```
Before: 3.75s
After:  3.13s
Decrease: 0.62s, 16.53%
```

Test:
- Run `run_tests.py`
- Parse my own .fit file, inspect data