### PR TITLE
Readme fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ The easiest way to grab :mod:`fitparse` is using ``pip``,
 
 ::
 
-    $ pip install python-fitparse
+    $ pip install fitparse
 
 
 From github

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,12 +96,12 @@ Here's a simple program to print all the record fields in an activity file::
 
             # Print the records name and value (and units if it has any)
             if record_data.units:
-                print " * %s: %s %s" % (
+                print(" * %s: %s %s" % (
                     record_data.name, record_data.value, record_data.units,
-                )
+                ))
             else:
-                print " * %s: %s" % (record_data.name, record_data.value)
-        print
+                print(" * %s: %s" % (record_data.name, record_data.value))
+        print()
 
 
 License


### PR DESCRIPTION
 - fix PyPi package name
 - use print() with parenthesis in example