### PR TITLE
fix collections deprecation warning

### DIFF
--- a/fitparse/utils.py
+++ b/fitparse/utils.py
@@ -1,6 +1,9 @@
 import io
 import re
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 class FitParseError(ValueError):


### PR DESCRIPTION
Hi there,

first of all thank you very much for this nice package!

This PR fixes the current Deprecation Warning of the `collections` library I came across while running the tests of my project where I'm using `python-fitparse`:

```
venv/lib/python3.7/site-packages/fitparse/utils.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable
```

cheers, Fabian