### PR TITLE
Add datetime.time handler to fitdump

### DIFF
--- a/scripts/fitdump
+++ b/scripts/fitdump
@@ -89,6 +89,8 @@ class RecordJSONEncoder(json.JSONEncoder):
                     data.name: data.value for data in obj
                 }
             }
+        if isinstance(obj, datetime.time):
+            return str(obj)
         # Fall back to original to raise a TypeError
         return super(RecordJSONEncoder, self).default(obj)
 


### PR DESCRIPTION
My watch (Forerunner 735) includes two time entries which crashed the fitdump tool. I've added the datetime.time  handler to the RecordJSONEncoder class.