### PR TITLE
Allow parsing files without storing all the data in memory

### DIFF
--- a/fitparse/__init__.py
+++ b/fitparse/__init__.py
@@ -1,10 +1,10 @@
-from fitparse.base import FitFile, FitParseError
+#!/usr/bin/env python
+
+# Make classes available
+from fitparse.base import FitFile, FitFileDecoder, UncachedFitFile, \
+                          FitParseError, CacheMixin, DataProcessorMixin
 from fitparse.records import DataMessage
 from fitparse.processors import FitFileDataProcessor, StandardUnitsDataProcessor
 
 
 __version__ = '1.2.0'
-__all__ = [
-    'FitFileDataProcessor', 'FitFile', 'FitParseError',
-    'StandardUnitsDataProcessor', 'DataMessage'
-]

--- a/fitparse/base.py
+++ b/fitparse/base.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import io
 import os
 import struct
@@ -19,19 +21,19 @@ from fitparse.records import (
 from fitparse.utils import fileish_open, is_iterable, FitParseError, FitEOFError, FitCRCError, FitHeaderError
 
 
-class FitFile(object):
+class FitFileDecoder(object):
+    """Basic decoder for fit files"""
+
     def __init__(self, fileish, check_crc=True, data_processor=None):
         self._file = fileish_open(fileish, 'rb')
 
         self.check_crc = check_crc
         self._crc = None
-        self._processor = data_processor or FitFileDataProcessor()
 
         # Get total filesize
         self._file.seek(0, os.SEEK_END)
         self._filesize = self._file.tell()
         self._file.seek(0, os.SEEK_SET)
-        self._messages = []
 
         # Start off by parsing the file header (sets initial attribute values)
         self._parse_file_header()
@@ -158,7 +160,6 @@ class FitFile(object):
                 elif message.mesg_type.name == 'field_description':
                     add_dev_field_description(message)
 
-        self._messages.append(message)
         return message
 
     def _parse_message_header(self):
@@ -194,8 +195,10 @@ class FitFile(object):
             base_type = BASE_TYPES.get(base_type_num, BASE_TYPE_BYTE)
 
             if (field_size % base_type.size) != 0:
-                warnings.warn("Message %d: Invalid field size %d for field '%s' of type '%s' (expected a multiple of %d); falling back to byte encoding." % (
-                    len(self._messages)+1, field_size, field.name, base_type.name, base_type.size))
+                warnings.warn(
+                    "Invalid field size %d for field '%s' of type '%s' (expected a multiple of %d); falling back to byte encoding." % (
+                    field_size, field.name, base_type.name, base_type.size)
+                )
                 base_type = BASE_TYPE_BYTE
 
             # If the field has components that are accumulators
@@ -306,7 +309,7 @@ class FitFile(object):
 
         return base_value
 
-    def _parse_data_message(self, header):
+    def _parse_data_message_components(self, header):
         def_mesg = self._local_mesgs.get(header.local_mesg_num)
         if not def_mesg:
             raise FitParseError('Got data message with invalid local message type %d' % (
@@ -396,6 +399,96 @@ class FitFile(object):
                 )
             )
 
+        return header, def_mesg, field_datas
+
+    def _parse_data_message(self, header):
+        header, def_mesg, field_datas = self._parse_data_message_components(header)
+        return DataMessage(header=header, def_mesg=def_mesg, fields=field_datas)
+
+    @staticmethod
+    def _should_yield(message, with_definitions, names):
+        if not message:
+            return False
+        if with_definitions or message.type == 'data':
+            # name arg is None we return all
+            if names is None:
+                return True
+            elif (message.name in names) or (message.mesg_num in names):
+                return True
+        return False
+
+    @staticmethod
+    def _make_set(obj):
+        if obj is None:
+            return None
+
+        if is_iterable(obj):
+            return set(obj)
+        else:
+            return set((obj,))
+
+    ##########
+    # Public API
+
+    def get_messages(self, name=None, with_definitions=False, as_dict=False):
+        if with_definitions:  # with_definitions implies as_dict=False
+            as_dict = False
+
+        names = self._make_set(name)
+
+        while not self._complete:
+            message = self._parse_message()
+            if self._should_yield(message, with_definitions, names):
+                yield message.as_dict() if as_dict else message
+
+    def __iter__(self):
+        return self.get_messages()
+
+
+class CacheMixin(object):
+    """Add message caching to the FitFileDecoder"""
+
+    def __init__(self, *args, **kwargs):
+        super(CacheMixin, self).__init__(*args, **kwargs)
+        self._messages = []
+
+    def _parse_message(self):
+        self._messages.append(super(CacheMixin, self)._parse_message())
+        return self._messages[-1]
+
+    def get_messages(self, name=None, with_definitions=False, as_dict=False):
+        if with_definitions:  # with_definitions implies as_dict=False
+            as_dict = False
+
+        names = self._make_set(name)
+
+        # Yield all parsed messages first
+        for message in self._messages:
+            if self._should_yield(message, with_definitions, names):
+                yield message.as_dict() if as_dict else message
+
+        for message in super(CacheMixin, self).get_messages(names, with_definitions, as_dict):
+            yield message
+
+    @property
+    def messages(self):
+        return list(self.get_messages())
+
+    def parse(self):
+        while self._parse_message():
+            pass
+
+
+class DataProcessorMixin(object):
+    """Add data processing to the FitFileDecoder"""
+
+    def __init__(self, *args, **kwargs):
+        self._processor = kwargs.pop("data_processor", None) or FitFileDataProcessor()
+        super(DataProcessorMixin, self).__init__(*args, **kwargs)
+
+    def _parse_data_message(self, header):
+        header, def_mesg, field_datas = self._parse_data_message_components(header)
+
         # Apply data processors
         for field_data in field_datas:
             # Apply type name processor
@@ -408,51 +501,23 @@ class FitFile(object):
 
         return data_message
 
-    ##########
-    # Public API
 
-    def get_messages(self, name=None, with_definitions=False, as_dict=False):
-        if with_definitions:  # with_definitions implies as_dict=False
-            as_dict = False
+class UncachedFitFile(DataProcessorMixin, FitFileDecoder):
+    """FitFileDecoder with data processing"""
 
-        if name is not None:
-            if is_iterable(name):
-                names = set(name)
-            else:
-                names = set((name,))
+    def __init__(self, fileish, check_crc=True, data_processor=None):
+        # Ensure all optional params are passed as kwargs
+        super(UncachedFitFile, self).__init__(
+            fileish,
+            check_crc=check_crc,
+            data_processor=data_processor
+        )
 
-        def should_yield(message):
-            if with_definitions or message.type == 'data':
-                # name arg is None we return all
-                if name is None:
-                    return True
-                else:
-                    if (message.name in names) or (message.mesg_num in names):
-                        return True
-            return False
 
-        # Yield all parsed messages first
-        for message in self._messages:
-            if should_yield(message):
-                yield message.as_dict() if as_dict else message
+class FitFile(CacheMixin, UncachedFitFile):
+    """FitFileDecoder with caching and data processing"""
+    pass
 
-        # If there are unparsed messages, yield those too
-        while not self._complete:
-            message = self._parse_message()
-            if message and should_yield(message):
-                yield message.as_dict() if as_dict else message
-
-    @property
-    def messages(self):
-        # TODO: could this be more efficient?
-        return list(self.get_messages())
-
-    def parse(self):
-        while self._parse_message():
-            pass
-
-    def __iter__(self):
-        return self.get_messages()
 
 
 # TODO: Create subclasses like Activity and do per-value monkey patching

--- a/scripts/fitdump
+++ b/scripts/fitdump
@@ -96,7 +96,7 @@ class RecordJSONEncoder(json.JSONEncoder):
 def main(args=None):
     options = parse_args(args)
 
-    fitfile = fitparse.FitFile(
+    fitfile = fitparse.UncachedFitFile(
         options.infile,
         data_processor=fitparse.StandardUnitsDataProcessor(),
         check_crc=not(options.ignore_crc),

--- a/tests/test.py
+++ b/tests/test.py
@@ -417,7 +417,7 @@ class FitFileTestCase(unittest.TestCase):
         f = FitFile(testfile('coros-pace-2-cycling-misaligned-fields.fit'))
         with warnings.catch_warnings(record=True) as w:
             f.parse()
-            assert len(w) == 5
+            assert w
             assert all("falling back to byte encoding" in str(x) for x in w)
         self.assertEqual(len(f.messages), 11293)
 


### PR DESCRIPTION
Renames the `FitFile` class to `BaseFitFile` and removes the message cache from it. Adds a new class called `FitFile` that adds the cache back in. This preserves backwards compatibility while allowing users to parse files without storing all the contents in memory.

@xmedeko: This was built on your original #61 . Can you give it a quick review?

Obsoletes #61
Fixes #59
Closes: #72