### PR TITLE
track record file positions to allow for record editing

### DIFF
--- a/fitparse/records.py
+++ b/fitparse/records.py
@@ -168,7 +168,7 @@ class DataMessage(RecordBase):
 
 
 class FieldData(RecordBase):
-    __slots__ = ('field_def', 'field', 'parent_field', 'value', 'raw_value', 'units')
+    __slots__ = ('field_def', 'field', 'parent_field', 'value', 'raw_value', 'units', 'filepos')
 
     def __init__(self, *args, **kwargs):
         super(FieldData, self).__init__(self, *args, **kwargs)
@@ -224,12 +224,14 @@ class FieldData(RecordBase):
             'name': self.name, 'def_num': self.def_num, 'base_type': self.base_type.name,
             'type': self.type.name, 'units': self.units, 'value': self.value,
             'raw_value': self.raw_value,
+            'filepos': self.filepos,
         }
 
     def __repr__(self):
         return '<FieldData: %s: %s%s, def num: %d, type: %s (%s), raw value: %s>' % (
             self.name, self.value, ' [%s]' % self.units if self.units else '',
             self.def_num, self.type.name, self.base_type.name, self.raw_value,
+            self.filepos,
         )
 
     def __str__(self):


### PR DESCRIPTION
This PR adds the file positions of each record to the parsing code.

Motivation:   I have a garmin 66i that occasionally produces bad records ( corrupt time and/or very inaccurate gps coordinates).   With this record data added to fitparse, I was able to write a second script (based on fitdump) that as it reads a .fit file will write a new .fit file removing the bad records, keeping all other records and updating the checksums and other header data.   That "fixfit.py" script is in my fork.  It's not very polished so not included here.    

Submitting this PR, in case there is any interest in this type of capability.  longer term it would be great to see a python based .fit editor 

