### PR TITLE
fix: handle error when parsing field with sleep_time: 86400

### DIFF
--- a/fitparse/processors.py
+++ b/fitparse/processors.py
@@ -83,9 +83,18 @@ class FitFileDataProcessor(object):
 
     def process_type_localtime_into_day(self, field_data):
         if field_data.value is not None:
-            m, s = divmod(field_data.value, 60)
-            h, m = divmod(m, 60)
-            field_data.value = datetime.time(h, m, s)
+            # NOTE: Values larger or equal to 86400 should not be possible.
+            #       Additionally, if the value is exactly 86400, it will lead to an error when trying to
+            #       create the time with datetime.time(24, 0 , 0).
+            #
+            #       E.g. Garmin does add "sleep_time": 86400 to its fit files,
+            #       which causes an error if not properly handled.
+            if field_data.value >= 86400:
+                field_data.value = datetime.time.max
+            else:
+                m, s = divmod(field_data.value, 60)
+                h, m = divmod(m, 60)
+                field_data.value = datetime.time(h, m, s)
             field_data.units = None
 
 


### PR DESCRIPTION
Hi,

This is a proposed fix for the error as described in issue #132

Cheers,
Mathias