### PR TITLE
Cleanup Python versions used for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.x', 'pypy2', 'pypy3']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.x']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actions no longer supports Python versions prior to 3.7, including 2.7.
    
Also, `docs/index.rst` has declared 3.6 to be the minimum supported version since 06b68d684, and python-fitparse has not compiled with Python 2.7 since f9ad9871c5df05af1aee9b0a2aeb2a871aaff559 (which uses Python 3.x-only syntax).
