### PR TITLE
Update datetime module as datetime.datetime.utcfromtimestamp() is deprecated

### DIFF
--- a/fitparse/processors.py
+++ b/fitparse/processors.py
@@ -70,7 +70,7 @@ class FitFileDataProcessor:
     def process_type_date_time(self, field_data):
         value = field_data.value
         if value is not None and value >= 0x10000000:
-            field_data.value = datetime.datetime.utcfromtimestamp(UTC_REFERENCE + value)
+            field_data.value = datetime.datetime.fromtimestamp(timestamp=(UTC_REFERENCE + value), tz=datetime.timezone.utc).replace(tzinfo=None)
             field_data.units = None  # Units were 's', set to None
 
     def process_type_local_date_time(self, field_data):
@@ -78,7 +78,7 @@ class FitFileDataProcessor:
             # NOTE: This value was created on the device using it's local timezone.
             #       Unless we know that timezone, this value won't be correct. However, if we
             #       assume UTC, at least it'll be consistent.
-            field_data.value = datetime.datetime.utcfromtimestamp(UTC_REFERENCE + field_data.value)
+            field_data.value = datetime.datetime.fromtimestamp(timestamp=(UTC_REFERENCE + field_data.value), tz=datetime.timezone.utc).replace(tzinfo=None)
             field_data.units = None
 
     def process_type_localtime_into_day(self, field_data):

--- a/tests/test.py
+++ b/tests/test.py
@@ -66,7 +66,7 @@ def generate_fitfile(data=None, endian='<'):
 
 
 def secs_to_dt(secs):
-    return datetime.datetime.utcfromtimestamp(secs + UTC_REFERENCE)
+    return datetime.datetime.fromtimestamp(timestamp=(secs + UTC_REFERENCE), tz=datetime.timezone.utc).replace(tzinfo=None)
 
 
 def testfile(filename):


### PR DESCRIPTION
This pull request addresses the deprecation warning related to `datetime.datetime.utcfromtimestamp()`, which is scheduled for removal in a future version of Python. The `utcfromtimestamp()` method is replaced with `datetime.datetime.fromtimestamp()` using `datetime.timezone.utc` to ensure that the datetime objects are timezone-aware and comply with the updated recommendations in Python's documentation.